### PR TITLE
Feature/miso 65 restringir boton continuar

### DIFF
--- a/src/app/contenido-interactivo/question-modal/question-modal.component.html
+++ b/src/app/contenido-interactivo/question-modal/question-modal.component.html
@@ -23,7 +23,7 @@
         <div class="col-3" *ngIf="!hasFeedBack" mat-dialog-actions>
             <button mat-button (click)="saveAnswer()">Enviar respuestas</button>
         </div>
-        <div class="col-3" mat-dialog-actions>
+        <div class="col-3" *ngIf="canJump" mat-dialog-actions>
             <button mat-button (click)="continue()">Continuar</button>
         </div>
     </div>

--- a/src/app/contenido-interactivo/question-modal/question-modal.component.ts
+++ b/src/app/contenido-interactivo/question-modal/question-modal.component.ts
@@ -13,6 +13,10 @@ import { AnswerQuestion } from 'src/app/models/mark/answerQuestion.model';
 })
 export class QuestionModalComponent implements OnInit {
 
+  //Variable que indica la configuración del instructor para que el estudiante pueda o no saltar una pregunta
+  // En este caso esta variable restringe la visualización del botón continuar
+  // TODO : asignar el valor proveniente del contenido interactivo
+  canJump = false;
   showRetroAlimentation = false;
   arrayQuestionsForMark: Array<PreguntaOpcionMultiple> = new Array();
   questionInformation: PreguntaOpcionMultiple;

--- a/src/app/contenido-interactivo/question-modal/question-modal.component.ts
+++ b/src/app/contenido-interactivo/question-modal/question-modal.component.ts
@@ -5,6 +5,7 @@ import { PreguntaOpcionMultiple } from 'src/app/models/mark/questionMultiple.mod
 import { OpcionesPreguntaMultiple } from 'src/app/models/mark/optionsQuestionMultiple.model';
 import { LoadVideoService } from 'src/app/services/contenidoInter/load-video.service';
 import { AnswerQuestion } from 'src/app/models/mark/answerQuestion.model';
+import Swal from 'sweetalert2';
 
 @Component({
   selector: 'app-question-modal',
@@ -15,8 +16,8 @@ export class QuestionModalComponent implements OnInit {
 
   //Variable que indica la configuración del instructor para que el estudiante pueda o no saltar una pregunta
   // En este caso esta variable restringe la visualización del botón continuar
-  // TODO : asignar el valor proveniente del contenido interactivo
-  canJump = false;
+  // TODO : asignar el valor proveniente del contenido interactivo, tal vez de la variable PreguntaOpcionMultiple
+  canJump = true;
   showRetroAlimentation = false;
   arrayQuestionsForMark: Array<PreguntaOpcionMultiple> = new Array();
   questionInformation: PreguntaOpcionMultiple;
@@ -41,10 +42,18 @@ export class QuestionModalComponent implements OnInit {
 
   saveAnswer() {
     this.hasFeedBack = this.arrayQuestionsForMark[this.indexToShow].tieneRetroalimentacion;
-    this.callServiceSaveAnswer();
-    if (!this.hasFeedBack) {
-      this.continue();
+    if(this.optionsArray.some(this.hasAnswer)){
+      this.callServiceSaveAnswer();
+      if (!this.hasFeedBack) {
+        this.continue();
+      }
+    }else{
+      Swal.fire('Cuidado', 'No ha respondido la pregunta', 'warning');
     }
+  }
+
+  hasAnswer(element, index, array) {
+    return element.answerOption;
   }
 
   continue() {

--- a/src/app/services/activities-service/activities.service.ts
+++ b/src/app/services/activities-service/activities.service.ts
@@ -64,5 +64,4 @@ export class ActivitiesService {
       }
     );
   }
-
 }


### PR DESCRIPTION
Se agrega manejo de la ventana para responder una pregunta dependiendo de la configuración sobre poder o no saltar una marca.
Si se puede saltar en la pregunta (canJump=true), se mantiene el comportamiento actual.
En el caso contrario, se esconde el botón "continuar" y se exige una respuesta a la pregunta 